### PR TITLE
slicing not required in orthonormal eigVecs

### DIFF
--- a/src/piDMD.m
+++ b/src/piDMD.m
@@ -63,7 +63,7 @@ elseif strcmp(method,'orthogonal')
     elseif nargout>2
         [eVecs,eVals] = eig(Aproj);
         varargout{1} = diag(eVals);
-        varargout{2} = Ux(:,1:r)*eVecs;
+        varargout{2} = Ux*eVecs;
         if nargout > 3; varargout{3} = Aproj; end
     end
     


### PR DESCRIPTION
I was a little confused with this slicing as Ux was already sliced. It doesn't cause any error, but thought its good to be consistent with `exact` / `exactSVDs` case !