### PR TITLE
Fix for issue in orthogonalExample.m where piDMD could not be found

### DIFF
--- a/examples/orthogonalExample.m
+++ b/examples/orthogonalExample.m
@@ -1,6 +1,7 @@
 % A simple test for the conservative piDMD (i.e. the orthogonal Procrustes
 % problem)
 
+addpath('../src') % Path for piDMD
 rng(1); % Set random seed
 n = 10; % Number of features
 m = 1e3; % Number of samples


### PR DESCRIPTION
added '/src' to path, now orthogonalExample.m can find piDMD and run successfully. 